### PR TITLE
Arg sim

### DIFF
--- a/utils/args.py
+++ b/utils/args.py
@@ -4,37 +4,107 @@ Utilities for generating and converting ARGs in various formats.
 import random
 import math
 import dataclasses
+from typing import List
+import itertools
 
 import intervaltree
 import tskit
 
 NODE_IS_RECOMB = 1 << 1
+NODE_IS_NONCOAL_CA = 1 << 2  # TODO better name
+
+
+@dataclasses.dataclass
+class Interval:
+    """
+    A class representing a interval.
+    """
+
+    left: int
+    right: int
+    node: int = -1
+    ancestral_to: int = -1
 
 
 @dataclasses.dataclass
 class Lineage:
-    node: int
-    ancestry: intervaltree.IntervalTree()
+    ancestry: List[Interval]
 
     @property
     def num_recombination_links(self):
-        return self.ancestry.span() - 1
+        return self.right - self.left - 1
 
     @property
     def left(self):
         """
         Returns the leftmost position of ancestral material.
         """
-        return self.ancestry.begin()
+        return self.ancestry[0].left
 
     @property
     def right(self):
         """
         Returns the rightmost position of ancestral material.
         """
-        return self.ancestry.end()
+        return self.ancestry[-1].right
+
+    def split(self, breakpoint):
+        """
+        Splits the ancestral material for this lineage at the specified
+        breakpoint, and returns a second lineage with the ancestral
+        material to the right.
+        """
+        left_ancestry = []
+        right_ancestry = []
+        for interval in self.ancestry:
+            if interval.right <= breakpoint:
+                left_ancestry.append(interval)
+            elif interval.left >= breakpoint:
+                right_ancestry.append(interval)
+            else:
+                assert interval.left < breakpoint < interval.right
+                left_ancestry.append(dataclasses.replace(interval, right=breakpoint))
+                right_ancestry.append(dataclasses.replace(interval, left=breakpoint))
+        self.ancestry = left_ancestry
+        return Lineage(right_ancestry)
 
 
+def overlapping_segments(segments):
+    """
+    Returns an iterator over the (left, right, X) tuples describing the
+    distinct overlapping segments in the specified set.
+    """
+    S = sorted(segments, key=lambda x: x.left)
+    n = len(S)
+    # Insert a sentinel at the end for convenience.
+    S.append(Interval(math.inf, 0))
+    right = S[0].left
+    X = []
+    j = 0
+    while j < n:
+        # Remove any elements of X with right <= left
+        left = right
+        X = [x for x in X if x.right > left]
+        if len(X) == 0:
+            left = S[j].left
+        while j < n and S[j].left == left:
+            X.append(S[j])
+            j += 1
+        j -= 1
+        right = min(x.right for x in X)
+        right = min(right, S[j + 1].left)
+        yield left, right, X
+        j += 1
+
+    while len(X) > 0:
+        left = right
+        X = [x for x in X if x.right > left]
+        if len(X) > 0:
+            right = min(x.right for x in X)
+            yield left, right, X
+
+
+# NOTE! This hasn't been statistically tested and is probably not correct.
 def arg_sim(n, rho, L, seed=None):
     rng = random.Random(seed)
     tables = tskit.TableCollection(L)
@@ -42,18 +112,18 @@ def arg_sim(n, rho, L, seed=None):
     lineages = []
     for _ in range(n):
         node = tables.nodes.add_row(time=0, flags=tskit.NODE_IS_SAMPLE)
-        lineages.append(Lineage(
-            node, intervaltree.IntervalTree.from_tuples([(0, L)])))
+        lineages.append(Lineage([Interval(0, L, node, 1)]))
 
     t = 0
     while len(lineages) > 0:
         # print(lineages)
         lineage_links = [lineage.num_recombination_links for lineage in lineages]
+        # print(lineage_links)
         total_links = sum(lineage_links)
-        re_rate = sum(lineage_links) * rho
+        re_rate = total_links * rho
         t_re = math.inf if re_rate == 0 else rng.expovariate(re_rate)
         k = len(lineages)
-        print("t = ", t, "k=", k, "lineage_links", total_links)
+        # print("t = ", t, "k=", k, "lineage_links", total_links)
         ca_rate = k * (k - 1) / 2
         t_ca = rng.expovariate(ca_rate)
         t_inc = min(t_re, t_ca)
@@ -61,58 +131,52 @@ def arg_sim(n, rho, L, seed=None):
         if t_inc == t_re:
             # Choose a lineage to recombine with probability equal to the
             # number of recombination links it subtends.
-            index = rng.choices(range(k), weights=lineage_links)[0]
-            lineage = lineages.pop(index)
+            lineage = rng.choices(lineages, weights=lineage_links)[0]
 
             # Choose a breakpoint uniformly on that lineage
             breakpoint = rng.randrange(lineage.left + 1, lineage.right)
             assert lineage.left < breakpoint < lineage.right
-            print("RE", breakpoint, lineage)
             node = tables.nodes.add_row(
                 flags=NODE_IS_RECOMB, time=t, metadata={"breakpoint": breakpoint}
             )
-
-            # Note: update for Griffiths ARG
-            # for interval in lineage.ancestry:
-            #     tables.edges.add_row(interval.begin, interval.end, node, lineage.node)
-
-            left = lineage.ancestry
-            right = left.copy()
-            right.chop(0, breakpoint)
-            left.chop(breakpoint, L)
-            # left = intervaltree.IntervalTree.from_tuples(
-            #     (interval.begin, interval.end) for interval in left)
-            # right = intervaltree.IntervalTree.from_tuples(
-            #     (interval.begin, interval.end) for interval in right)
-            lineages.extend([Lineage(node, left), Lineage(node, right)])
-
+            right = lineage.split(breakpoint)
+            lineages.append(right)
+            for lineage in [lineage, right]:
+                for interval in lineage.ancestry:
+                    tables.edges.add_row(
+                        interval.left, interval.right, node, interval.node
+                    )
+                    interval.node = node
 
         else:
-            print("CA EVENT")
-            a_index = rng.randrange(k)
-            b_index = rng.randrange(k - 1)
-            a = lineages.pop(a_index)
-            b = lineages.pop(b_index)
+            # print("CA EVENT")
+            a = lineages.pop(rng.randrange(len(lineages)))
+            b = lineages.pop(rng.randrange(len(lineages)))
+            # print("\ta = ", a)
+            # print("\tb = ", b)
+            ancestry = []
+            flags = NODE_IS_NONCOAL_CA
+            node = len(tables.nodes)
+            for left, right, U in overlapping_segments(a.ancestry + b.ancestry):
+                ancestral_to = sum(u.ancestral_to for u in U)
+                assert left < right
+                if len(U) > 1:
+                    flags = 0  # This is a coalescence, treat this as ordinary tree node
+                if ancestral_to < n:
+                    ancestry.append(Interval(left, right, node, ancestral_to))
+                for u in U:
+                    tables.edges.add_row(left, right, node, u.node)
+            tables.nodes.add_row(flags=flags, time=t, metadata={})
+            # print("\tdone:", ancestry)
+            if len(ancestry) > 0:
+                lineages.append(Lineage(ancestry))
+    # print()
+    # print(tables)
+    tables.sort()
+    # tables.simplify()
+    return tables.tree_sequence()
 
-            print("\ta = ", a)
-            print("\tb = ", b)
-            c = a.ancestry.union(b.ancestry)
-            # c.split_overlaps()
-            c.merge_overlaps()
-            # print("\tintersection = ", a.ancestry.intersection(b.ancestry))
-            print("\tc = ", c)
 
-            flags = 0
-            node = tables.nodes.add_row(flags=flags, time=t, metadata={})
-            # for lineage in [a, b]:
-            #     for interval in lineage:
-            #         tables.edges.add_row(interval.begin, interval.end, node, interval.data)
+ts = arg_sim(5, 0.1, 10, seed=234)
 
-
-            c = intervaltree.IntervalTree.from_tuples(
-                (interval.begin, interval.end) for interval in c)
-            lineages.append(Lineage(node, c))
-
-        print()
-
-arg_sim(5, 1, 10, seed=234)
+print(ts.draw_text())

--- a/utils/args.py
+++ b/utils/args.py
@@ -1,0 +1,118 @@
+"""
+Utilities for generating and converting ARGs in various formats.
+"""
+import random
+import math
+import dataclasses
+
+import intervaltree
+import tskit
+
+NODE_IS_RECOMB = 1 << 1
+
+
+@dataclasses.dataclass
+class Lineage:
+    node: int
+    ancestry: intervaltree.IntervalTree()
+
+    @property
+    def num_recombination_links(self):
+        return self.ancestry.span() - 1
+
+    @property
+    def left(self):
+        """
+        Returns the leftmost position of ancestral material.
+        """
+        return self.ancestry.begin()
+
+    @property
+    def right(self):
+        """
+        Returns the rightmost position of ancestral material.
+        """
+        return self.ancestry.end()
+
+
+def arg_sim(n, rho, L, seed=None):
+    rng = random.Random(seed)
+    tables = tskit.TableCollection(L)
+    tables.nodes.metadata_schema = tskit.MetadataSchema.permissive_json()
+    lineages = []
+    for _ in range(n):
+        node = tables.nodes.add_row(time=0, flags=tskit.NODE_IS_SAMPLE)
+        lineages.append(Lineage(
+            node, intervaltree.IntervalTree.from_tuples([(0, L)])))
+
+    t = 0
+    while len(lineages) > 0:
+        # print(lineages)
+        lineage_links = [lineage.num_recombination_links for lineage in lineages]
+        total_links = sum(lineage_links)
+        re_rate = sum(lineage_links) * rho
+        t_re = math.inf if re_rate == 0 else rng.expovariate(re_rate)
+        k = len(lineages)
+        print("t = ", t, "k=", k, "lineage_links", total_links)
+        ca_rate = k * (k - 1) / 2
+        t_ca = rng.expovariate(ca_rate)
+        t_inc = min(t_re, t_ca)
+        t += t_inc
+        if t_inc == t_re:
+            # Choose a lineage to recombine with probability equal to the
+            # number of recombination links it subtends.
+            index = rng.choices(range(k), weights=lineage_links)[0]
+            lineage = lineages.pop(index)
+
+            # Choose a breakpoint uniformly on that lineage
+            breakpoint = rng.randrange(lineage.left + 1, lineage.right)
+            assert lineage.left < breakpoint < lineage.right
+            print("RE", breakpoint, lineage)
+            node = tables.nodes.add_row(
+                flags=NODE_IS_RECOMB, time=t, metadata={"breakpoint": breakpoint}
+            )
+
+            # Note: update for Griffiths ARG
+            # for interval in lineage.ancestry:
+            #     tables.edges.add_row(interval.begin, interval.end, node, lineage.node)
+
+            left = lineage.ancestry
+            right = left.copy()
+            right.chop(0, breakpoint)
+            left.chop(breakpoint, L)
+            # left = intervaltree.IntervalTree.from_tuples(
+            #     (interval.begin, interval.end) for interval in left)
+            # right = intervaltree.IntervalTree.from_tuples(
+            #     (interval.begin, interval.end) for interval in right)
+            lineages.extend([Lineage(node, left), Lineage(node, right)])
+
+
+        else:
+            print("CA EVENT")
+            a_index = rng.randrange(k)
+            b_index = rng.randrange(k - 1)
+            a = lineages.pop(a_index)
+            b = lineages.pop(b_index)
+
+            print("\ta = ", a)
+            print("\tb = ", b)
+            c = a.ancestry.union(b.ancestry)
+            # c.split_overlaps()
+            c.merge_overlaps()
+            # print("\tintersection = ", a.ancestry.intersection(b.ancestry))
+            print("\tc = ", c)
+
+            flags = 0
+            node = tables.nodes.add_row(flags=flags, time=t, metadata={})
+            # for lineage in [a, b]:
+            #     for interval in lineage:
+            #         tables.edges.add_row(interval.begin, interval.end, node, interval.data)
+
+
+            c = intervaltree.IntervalTree.from_tuples(
+                (interval.begin, interval.end) for interval in c)
+            lineages.append(Lineage(node, c))
+
+        print()
+
+arg_sim(5, 1, 10, seed=234)

--- a/utils/args.py
+++ b/utils/args.py
@@ -5,9 +5,8 @@ import random
 import math
 import dataclasses
 from typing import List
-import itertools
+from typing import Any
 
-import intervaltree
 import tskit
 
 NODE_IS_RECOMB = 1 << 1
@@ -15,28 +14,21 @@ NODE_IS_NONCOAL_CA = 1 << 2  # TODO better name
 
 
 @dataclasses.dataclass
-class Interval:
-    """
-    A class representing a interval.
-    """
-
+class AncestryInterval:
     left: int
     right: int
-    node: int = -1
-    ancestral_to: int = -1
+    ancestral_to: int
 
 
 @dataclasses.dataclass
 class Lineage:
     node: int
-    ancestry: List[Interval]
+    ancestry: List[AncestryInterval]
 
     def __str__(self):
         s = f"{self.node}:["
         for interval in self.ancestry:
-            s += str(
-                (interval.left, interval.right, interval.node, interval.ancestral_to)
-            )
+            s += str((interval.left, interval.right, interval.ancestral_to))
             s += ", "
         return s[:-2] + "]"
 
@@ -79,6 +71,13 @@ class Lineage:
         return Lineage(self.node, right_ancestry)
 
 
+@dataclasses.dataclass
+class MappingSegment:
+    left: int
+    right: int
+    value: Any = None
+
+
 def overlapping_segments(segments):
     """
     Returns an iterator over the (left, right, X) tuples describing the
@@ -87,7 +86,7 @@ def overlapping_segments(segments):
     S = sorted(segments, key=lambda x: x.left)
     n = len(S)
     # Insert a sentinel at the end for convenience.
-    S.append(Interval(math.inf, 0))
+    S.append(MappingSegment(math.inf, 0))
     right = S[0].left
     X = []
     j = 0
@@ -113,97 +112,96 @@ def overlapping_segments(segments):
             right = min(x.right for x in X)
             yield left, right, X
 
+
 def merge_ancestry(lineages):
-    node_map = {lineage.node: lineage for lineage in lineages}
     segments = []
     for lineage in lineages:
-        segments.extend(lineage.ancestry)
+        for interval in lineage.ancestry:
+            segments.append(
+                MappingSegment(interval.left, interval.right, (lineage, interval))
+            )
 
     for left, right, U in overlapping_segments(segments):
-        ancestral_to = sum(u.ancestral_to for u in U)
-        interval = Interval(left, right, -1, ancestral_to)
-        yield interval, [node_map[u.node] for u in U]
+        ancestral_to = sum(u.value[1].ancestral_to for u in U)
+        interval = AncestryInterval(left, right, ancestral_to)
+        yield interval, [u.value[0] for u in U]
+
+
+class ArgSimulator:
+    def __init__(self, num_samples, rho, L, seed):
+        self.num_samples = num_samples
+        self.L = L
+        self.rho = rho
+        self.rng = random.Random(seed)
+        self.tables = tskit.TableCollection(L)
+        self.tables.nodes.metadata_schema = tskit.MetadataSchema.permissive_json()
+        self.lineages = []
+        for _ in range(num_samples):
+            node = self.tables.nodes.add_row(time=0, flags=tskit.NODE_IS_SAMPLE)
+            self.lineages.append(Lineage(node, [AncestryInterval(0, L, 1)]))
+
+    def run(self):
+        t = 0
+        while len(self.lineages) > 0:
+            # print(f"t = {t:.2f} k = {len(lineages)}")
+            # for lineage in lineages:
+            #     print(f"\t{lineage}")
+            lineage_links = [lineage.num_recombination_links for lineage in self.lineages]
+            total_links = sum(lineage_links)
+            re_rate = total_links * self.rho
+            t_re = math.inf if re_rate == 0 else self.rng.expovariate(re_rate)
+            k = len(self.lineages)
+            ca_rate = k * (k - 1) / 2
+            t_ca = self.rng.expovariate(ca_rate)
+            t_inc = min(t_re, t_ca)
+            t += t_inc
+            if t_inc == t_re:
+                lineage = self.rng.choices(self.lineages, weights=lineage_links)[0]
+                breakpoint = self.rng.randrange(lineage.left + 1, lineage.right)
+                assert lineage.left < breakpoint < lineage.right
+                node = self.tables.nodes.add_row(
+                    flags=NODE_IS_RECOMB, time=t, metadata={"breakpoint": breakpoint}
+                )
+                right = lineage.split(breakpoint)
+                self.lineages.append(right)
+                for lineage in [lineage, right]:
+                    for interval in lineage.ancestry:
+                        self.tables.edges.add_row(
+                            interval.left, interval.right, node, lineage.node
+                        )
+                    lineage.node = node
+            else:
+                a = self.lineages.pop(self.rng.randrange(len(self.lineages)))
+                b = self.lineages.pop(self.rng.randrange(len(self.lineages)))
+                # print(f"\ta = {a}")
+                # print(f"\tb = {b}")
+                c = Lineage(len(self.tables.nodes), [])
+                flags = NODE_IS_NONCOAL_CA
+                for interval, intersecting_lineages in merge_ancestry([a, b]):
+                    if len(intersecting_lineages) > 1:
+                        flags = 0  # This is a coalescence, treat this as ordinary tree node
+                    if interval.ancestral_to < self.num_samples:
+                        c.ancestry.append(interval)
+                    for lineage in intersecting_lineages:
+                        self.tables.edges.add_row(
+                            interval.left, interval.right, c.node, lineage.node
+                        )
+                self.tables.nodes.add_row(flags=flags, time=t, metadata={})
+                # print(f"\tc = {c}")
+                if len(c.ancestry) > 0:
+                    self.lineages.append(c)
+
+        self.tables.sort()
+        return self.tables.tree_sequence()
 
 # NOTE! This hasn't been statistically tested and is probably not correct.
 def arg_sim(n, rho, L, seed=None):
-    rng = random.Random(seed)
-    tables = tskit.TableCollection(L)
-    tables.nodes.metadata_schema = tskit.MetadataSchema.permissive_json()
-    lineages = []
-    for _ in range(n):
-        node = tables.nodes.add_row(time=0, flags=tskit.NODE_IS_SAMPLE)
-        lineages.append(Lineage(node, [Interval(0, L, node, 1)]))
-
-    t = 0
-    while len(lineages) > 0:
-        print(f"t = {t:.2f} k = {len(lineages)}")
-        for lineage in lineages:
-            print(f"\t{lineage}")
-        lineage_links = [lineage.num_recombination_links for lineage in lineages]
-        total_links = sum(lineage_links)
-        re_rate = total_links * rho
-        t_re = math.inf if re_rate == 0 else rng.expovariate(re_rate)
-        k = len(lineages)
-        ca_rate = k * (k - 1) / 2
-        t_ca = rng.expovariate(ca_rate)
-        t_inc = min(t_re, t_ca)
-        t += t_inc
-        if t_inc == t_re:
-            # Choose a lineage to recombine with probability equal to the
-            # number of recombination links it subtends.
-            lineage = rng.choices(lineages, weights=lineage_links)[0]
-            # Choose a breakpoint uniformly on that lineage
-            breakpoint = rng.randrange(lineage.left + 1, lineage.right)
-            assert lineage.left < breakpoint < lineage.right
-            node = tables.nodes.add_row(
-                flags=NODE_IS_RECOMB, time=t, metadata={"breakpoint": breakpoint}
-            )
-            right = lineage.split(breakpoint)
-            lineages.append(right)
-            for lineage in [lineage, right]:
-                # lineage.node = node
-                for interval in lineage.ancestry:
-                    tables.edges.add_row(
-                        interval.left, interval.right, node, lineage.node
-                    )
-                    interval.node = node
-                lineage.node = node
-
-        else:
-            # print("CA EVENT")
-            a = lineages.pop(rng.randrange(len(lineages)))
-            b = lineages.pop(rng.randrange(len(lineages)))
-            print(f"\ta = {a}")
-            print(f"\tb = {b}")
-            ancestry = []
-            flags = NODE_IS_NONCOAL_CA
-            node = len(tables.nodes)
-            # for left, right, U in overlapping_segments(a.ancestry + b.ancestry):
-            for interval, intersecting_lineages in merge_ancestry([a, b]):
-                # ancestral_to = sum(u.ancestral_to for u in U)
-                # assert left < right
-                if len(intersecting_lineages) > 1:
-                    flags = 0  # This is a coalescence, treat this as ordinary tree node
-                if interval.ancestral_to < n:
-                    interval.node = node
-                    ancestry.append(interval)
-                for lineage in intersecting_lineages:
-                    tables.edges.add_row(interval.left, interval.right, node,
-                            lineage.node)
-            tables.nodes.add_row(flags=flags, time=t, metadata={})
-            # print("\tdone:", ancestry)
-            if len(ancestry) > 0:
-                c = Lineage(node, ancestry)
-                print(f"\tc = {c}")
-                lineages.append(c)
-    # print()
-    # print(tables)
-    tables.sort()
-    # tables.simplify()
-    return tables.tree_sequence()
+    sim = ArgSimulator(n, rho, L, seed)
+    return sim.run()
 
 
 ts = arg_sim(5, 0.2, 10, seed=234)
+print(ts.tables)
 
 node_labels = {}
 for node in ts.nodes():

--- a/utils/args.py
+++ b/utils/args.py
@@ -3,15 +3,28 @@ Utilities for generating and converting ARGs in various formats.
 """
 import random
 import math
+import collections
 import dataclasses
 from typing import List
 from typing import Any
 
 import tskit
+import numpy as np
 
 NODE_IS_RECOMB = 1 << 1
 NODE_IS_NONCOAL_CA = 1 << 2  # TODO better name
 
+def draw_arg(ts):
+
+    node_labels = {}
+    for node in ts.nodes():
+        label = str(node.id)
+        if node.flags == NODE_IS_RECOMB:
+            label = f"R{node.id}"
+        elif node.flags == NODE_IS_NONCOAL_CA:
+            label = f"N{node.id}"
+        node_labels[node.id] = label
+    print(ts.draw_text(node_labels=node_labels))
 
 @dataclasses.dataclass
 class AncestryInterval:
@@ -30,7 +43,9 @@ class Lineage:
         for interval in self.ancestry:
             s += str((interval.left, interval.right, interval.ancestral_to))
             s += ", "
-        return s[:-2] + "]"
+        if len(self.ancestry) > 0:
+            s = s[:-2]
+        return s + "]"
 
     @property
     def num_recombination_links(self):
@@ -191,14 +206,155 @@ def arg_sim(n, rho, L, seed=None):
     return tables.tree_sequence()
 
 
-ts = arg_sim(5, 0.2, 10, seed=234)
+# NOTE! This hasn't been statistically tested and is probably not correct.
+def node_arg_sim(n, rho, L, seed=None):
+    rng = random.Random(seed)
+    tables = tskit.TableCollection(L)
+    tables.nodes.metadata_schema = tskit.MetadataSchema.permissive_json()
 
-node_labels = {}
-for node in ts.nodes():
-    label = str(node.id)
-    if node.flags == NODE_IS_RECOMB:
-        label = f"R{node.id}"
-    elif node.flags == NODE_IS_NONCOAL_CA:
-        label = f"N{node.id}"
-    node_labels[node.id] = label
-print(ts.draw_text(node_labels=node_labels))
+    lineages = []
+    for _ in range(n):
+        node = tables.nodes.add_row(time=0, flags=tskit.NODE_IS_SAMPLE)
+        lineages.append(Lineage(node, [AncestryInterval(0, L, 1)]))
+    t = 0
+    while len(lineages) > 0:
+        print(f"t = {t:.2f} k = {len(lineages)}")
+        for lineage in lineages:
+            print(f"\t{lineage}")
+        lineage_links = [lineage.num_recombination_links for lineage in lineages]
+        total_links = sum(lineage_links)
+        re_rate = total_links * rho
+        t_re = math.inf if re_rate == 0 else rng.expovariate(re_rate)
+        k = len(lineages)
+        ca_rate = k * (k - 1) / 2
+        t_ca = rng.expovariate(ca_rate)
+        t_inc = min(t_re, t_ca)
+        t += t_inc
+        if t_inc == t_re:
+            lineage = rng.choices(lineages, weights=lineage_links)[0]
+            breakpoint = rng.randrange(lineage.left + 1, lineage.right)
+            assert lineage.left < breakpoint < lineage.right
+            node = tables.nodes.add_row(
+                flags=NODE_IS_RECOMB, time=t, metadata={"breakpoint": breakpoint}
+            )
+            tables.edges.add_row(-math.inf, math.inf, node, lineage.node)
+            lineage.node = node
+            right = lineage.split(breakpoint)
+            lineages.append(right)
+        else:
+            a = lineages.pop(rng.randrange(len(lineages)))
+            b = lineages.pop(rng.randrange(len(lineages)))
+            c = Lineage(len(tables.nodes), [])
+            flags = NODE_IS_NONCOAL_CA
+            for interval, intersecting_lineages in merge_ancestry([a, b]):
+                if len(intersecting_lineages) > 1:
+                    flags = 0  # This is a coalescence, treat this as ordinary tree node
+                if interval.ancestral_to < n:
+                    c.ancestry.append(interval)
+            tables.nodes.add_row(flags=flags, time=t, metadata={})
+            tables.edges.add_row(-math.inf, math.inf, c.node, a.node)
+            tables.edges.add_row(-math.inf, math.inf, c.node, b.node)
+            # print(f"\tc = {c}")
+            if len(c.ancestry) > 0:
+                lineages.append(c)
+    # tables.sort()
+    # return tables.tree_sequence()
+    return tables
+
+
+def convert_arg(tables):
+    """
+    Converts the specified non-ancestry tracking ARG to a tskit ARG.
+    """
+    out = tables.copy()
+    out.edges.clear()
+    nodes = sorted(tables.nodes, key=lambda x: x.time)
+
+    parent = collections.defaultdict(list)
+    children = collections.defaultdict(list)
+    for edge in tables.edges:
+        parent[edge.child].append(edge.parent)
+        children[edge.parent].append(edge.child)
+
+    lineages = []
+    node_id = 0
+    n = 0
+    while node_id < len(nodes) and (nodes[node_id].flags & tskit.NODE_IS_SAMPLE != 0):
+        node = nodes[node_id]
+        print("sample:", node)
+        assert nodes[node_id].time == 0
+        lineages.append(Lineage(node_id, [AncestryInterval(0, tables.sequence_length, 1)]))
+        node_id += 1
+        n += 1
+
+    for node_id in range(node_id, len(nodes)):
+        node = nodes[node_id]
+        parent = node_id
+        # print("VISIT", node_id, node.time)
+        # for lineage in lineages:
+        #     print(f"\t{lineage}")
+        if (node.flags & NODE_IS_RECOMB) != 0:
+            # print("RE EVENT")
+            child = children[parent][0]
+            assert len(children[parent]) == 1
+            # print(f"parent = {parent} child = {child}")
+            breakpoint = node.metadata["breakpoint"]
+            for lineage in lineages:
+                if lineage.node == child:
+                    break
+            right = lineage.split(breakpoint)
+            lineages.append(right)
+            for lineage in [lineage, right]:
+                for interval in lineage.ancestry:
+                    out.edges.add_row(
+                        interval.left, interval.right, parent, child,
+                    )
+                lineage.node = parent
+        else:
+            # print("COAL")
+            # print(children[parent])
+            assert len(children[parent]) == 2
+            children_lineages = []
+            for child in children[parent]:
+                for j in range(len(lineages)):
+                    if lineages[j].node == child:
+                        children_lineages.append(lineages.pop(j))
+                        break
+            a, b  = children_lineages
+            c = Lineage(parent, [])
+            flags = NODE_IS_NONCOAL_CA
+            for interval, intersecting_lineages in merge_ancestry([a, b]):
+                if len(intersecting_lineages) > 1:
+                    flags = 0  # This is a coalescence, treat this as ordinary tree node
+                if interval.ancestral_to < n:
+                    c.ancestry.append(interval)
+                for lineage in intersecting_lineages:
+                    out.edges.add_row(
+                        interval.left, interval.right, c.node, lineage.node
+                    )
+            # print(node.flags, flags)
+            # assert node.flags == flags
+            # tables.nodes.add_row(flags=flags, time=t, metadata={})
+            # print(f"\ta = {a}")
+            # print(f"\tb = {b}")
+            # print(f"\tc = {c}")
+            if len(c.ancestry) > 0:
+                lineages.append(c)
+        print(f"t = {node.time:.2f}")
+        for lineage in lineages:
+            print(f"\t{lineage}")
+    print(out)
+    out.sort()
+    return out.tree_sequence()
+
+n = 3
+rho = 0.3
+L = 10
+seed = 234
+ts = arg_sim(n, rho, L, seed=seed)
+# tables = node_arg_sim(n, rho, L, seed=seed)
+# print(tables)
+# ts2 = convert_arg(tables)
+
+draw_arg(ts)
+draw_arg(ts2)


### PR DESCRIPTION
I think we've made some real progress here! There's various things to talk about, but for now, here's the high-level stuff.

This PR adds some functions to simulate an ARG in two different encodings, and a function to convert one encoding into the other. The first encoding is what I'm calling "ancestry-resolved", and returns a well formed tskit TreeSequence (complete with all ARG nodes). The second encoding is non-resolved, close to what we'd think of as a classical Griffiths ARG: it just stores the nodes, (graph) edges between them and recombination breakpoints. The third function then converts the unresolved ARG into a full resolved one, so that we can get precisely the same final tree sequence by running the two different simulations under the same parameters. There's a bijection between the two forms.

A key insight here is that simulating an unresolved ARG is fundamentally pointless, since you *must* already have all the information required to output a resolved ARG in order to run the simulation. Unless you want to simulate back to the GMRCA (and filter out many pass-through nodes), you must keep track of the amount of ancestral material remaining in intervals along the genome, so that they can be "snipped out" once fully coalesced. It is precisely this information that we need in order to output an ancestry-resolved ARG. The process of resolving this Griffiths-like representation is then simply a case of "rerunning" the simulation, keeping track of the amount of ancestral material present along the genome so that we can record tree sequence edges.

There's some more notes in the code, which is hopefully (mostly) reasonably readable.

One really important thing that I realised here is that we *must* have two nodes for a recombination - otherwise, there is no bijection. You can't convert to a fully resolved ARG from an unresolved ARG with a single recombination node because there are (I think?) 2^k different resolutions consistent with it, corresponding to the two different ways that ancestry can go at each recombination breakpoint. We usually imagine that we adopt some rule to work around this, but I couldn't figure out any way to do it that would work for simulations. Anyway, a single recombination node is fundamentally unbiological when you think it through - I'll open a discussion to talk about this more.

Good to get your eyes on this @hyanwong and @JereKoskela. 