### PR TITLE
Fix recombination nodes.

### DIFF
--- a/utils/args.py
+++ b/utils/args.py
@@ -590,7 +590,7 @@ def simplest_example():
 # simplest_example()
 
 # ts = resolved_wf_arg_sim(2, 2, 4, 46)
-ts = arg_sim(6, 0.1, 50, 46)
+ts = arg_sim(6, 0.1, 5, 47)
 # print(ts.tables)
 
 draw_arg(ts)


### PR DESCRIPTION
I was wrong earlier that you could optionally include the parent nodes in a recombination event when we are associating the flags with the child node.

We *must* add the parent nodes and update the lineages, or we can have multiple recombination events hitting the same node/lineage. If you'd like to try it out, you can easily comment out chunks of code and see how the asserts trip.

You also must use two different parent nodes.