### PR TITLE
Modified first sentence, added references

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -998,3 +998,45 @@
   year={2016},
   publisher={SIAM}
 }
+
+
+@article{rannala2003genetics,
+	author = {Rannala, Bruce and Yang, Ziheng},
+	journal = {Genetics},
+	month = {08},
+	number = {4},
+	pages = {1645--1656},
+	title = {Bayes estimation of species divergence times and ancestral population sizes using DNA sequences from multiple loci},
+	volume = {164},
+	year = {2003}}
+
+
+@article{cann1987mitochondrial,
+	author = {Cann, Rebecca L. and Stoneking, Mark and Wilson, Allan C.},
+	journal = {Nature},
+	number = {6099},
+	pages = {31--36},
+	title = {Mitochondrial DNA and human evolution},
+	volume = {325},
+	year = {1987}}
+
+
+@article{grenfell2004science,
+	author = {Bryan T. Grenfell and Oliver G. Pybus and Julia R. Gog and James L. N. Wood and Janet M. Daly and Jenny A. Mumford and Edward C. Holmes},
+	journal = {Science},
+	number = {5656},
+	pages = {327-332},
+	title = {Unifying the Epidemiological and Evolutionary Dynamics of Pathogens},
+	volume = {303},
+	year = {2004}}
+	
+
+@article{underhill2001annalsofhumangenetics,
+	author = {Underhill, P. A. and Passarino, G. and Lin, A. A. and Shen, P. and Miraz{\'o}n Lahr, M. and Foley, R. A. and Oefner, P. J. and Cavalli-Sforza, L. L.},
+	journal = {Annals of Human Genetics},
+	number = {1},
+	pages = {43-62},
+	title = {The phylogeography of Y chromosome binary haplotypes and the origins of modern human populations},
+	volume = {65},
+	year = {2001}}
+

--- a/paper.tex
+++ b/paper.tex
@@ -65,8 +65,8 @@ and discuss the properties of some recently developed inference methods.
 
 \section*{Introduction}
 Inferring the genetic relationships between sampled genomes in the form of an
-evolutionary tree is a necessary prerequisite for many analyses of non (or
-rarely) recombining organisms [refs]. The tree captures what is known and
+evolutionary tree is a necessary prerequisite for many analyses of species \citep{rannala2003genetics}, non (or
+rarely) recombining sections of DNA \citep{cann1987mitochondrial,underhill2001annalsofhumangenetics} and viruses \citep{grenfell2004science}. The tree captures what is known and
 knowable about the genetic ancestry of the sample in an elegant and concise
 way, by postulating a set of nodes that are ancestors common to the samples,
 and the ancestral relationships between those nodes. A rich literature exists


### PR DESCRIPTION
I think the first sentence can be modified to better describe how evolutionary trees are practically used. I see the main categories of tree inference as: (1) species trees, (2) trees of non-recombining sections of genome, and (3) viral phylogenies. Do others like this classification?
Another reason to rephrase: we can't really cite viral phylogenetics papers with the current wording since viruses aren't usually referred to as "organisms".