### PR TITLE
add citations for pedigree arg relationship

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -1075,3 +1075,23 @@
   year = 2009
 }
 
+@article{speed2015naturereviewsgenetics,
+	author = {Speed, Doug and Balding, David J.},
+	journal = {Nature Reviews Genetics},
+	number = {1},
+	pages = {33--44},
+	title = {Relatedness in the post-genomic era: is it still useful?},
+	volume = {16},
+	year = {2015}}
+
+
+@article{wakeley2012genetics,
+	Author = {Wakeley, John and King, L{\'e}andra and Low, Bobbi S and Ramachandran, Sohini},
+	Journal = {Genetics},
+	Month = {Apr},
+	Number = {4},
+	Pages = {1433--1445},
+	Title = {Gene genealogies within a fixed pedigree, and the robustness of Kingman's coalescent.},
+	Volume = {190},
+	Year = {2012}}
+

--- a/paper.tex
+++ b/paper.tex
@@ -399,8 +399,9 @@ and no more.
 We describe here an alternative formulation in which the
 concepts are based on the diploid pedigree, which
 is free from the limitations discussed in the previous section.
-\cite{mathieson2020ancestry} and others [CITE] have also
-suggested this approach, although without explicitly defining
+\cite{mathieson2020ancestry} and others 
+\citep{wakeley2012genetics,gusfield2014recombinatorics,speed2015naturereviewsgenetics}
+have also suggested this approach, although without explicitly defining
 the roles of nodes and the details of how ancestry
 flows along edges.
 


### PR DESCRIPTION
Mathieson & Scally (2020) is cited as an example of the "ARG as a subset of the pedigree" analogy. A literature search turns up two other solid citations for this analogy:
Gusfield (2014), Section 1.2:
>**Tracing the transmission history of sequences** Now consider an individual in a population and just one of the homologs of a homologous pair of some
chromosome (say from chromosome 21). The sequence on that homolog was
transmitted to the individual from just one parent, and since there is no recombination, that sequence was passed down from exactly one grandparent, etc. It
follows that the transmission history of the chromosome sequence forms a path
through ancestors in the individual’s pedigree. That path begins at a founder
sequence and descends to the individual. Further, since we have assumed that
there is no mutation, each of the individual’s ancestors on the path possesses
and transmits an identical copy of the sequence.
>**Definition** The path through sequences (overlayed on a pedigree), showing the
transmission of a sequence from an ancestor of an individual, to that individual,
is called a sequence-transmission path. Note that the elements on the path are
sequences, rather than the people who possess those sequences.

Speed and Balding (2015):
>There is a fundamental connection between coalescent trees and pedigrees: a pedigree can be thought of as providing a 'scaffold' on which coalescent trees at different genomic loci are constructed. Pedigree members have maternal and paternal alleles at each locus, but each coalescent lineage passes through only one allele of each individual. Thus, we can consider the coalescent tree at a locus as a stochastic process on a fixed pedigree, making 'coin toss' decisions between the maternal and paternal chromosomes of each ancestor that is reached (see [Supplementary information S4 (box)]).