### PR TITLE
Refine argutils

### DIFF
--- a/argutils/__init__.py
+++ b/argutils/__init__.py
@@ -2,4 +2,4 @@
 Various utilities for working with args.
 """
 from . ancestry import *
-from . viz import *
+from . viz import draw

--- a/argutils/__main__.py
+++ b/argutils/__main__.py
@@ -1,5 +1,7 @@
 import click
 import argutils
+import tskit
+import matplotlib.pyplot as plt
 
 
 @click.group()
@@ -18,13 +20,19 @@ def simulate(num_samples, sequence_length, rho, seed, output):
     Simulate an ARG under the coalescent with recombination and write
     out the explicitly resolved ancestry result to file.
     """
-    ts = argutils.sim_arg(num_samples, rho, sequence_length, seed=seed)
+    ts = argutils.sim_coalescent(num_samples, rho, sequence_length, seed=seed)
+    print(ts)
     ts.dump(output)
 
 
 @click.command()
-def draw():
-    click.echo("IMPLEMENT ME")
+@click.argument("input", type=click.File("rb"))
+@click.argument("output", type=click.Path())
+def draw(input, output):
+    ts = tskit.load(input)
+    fig, ax1 = plt.subplots(1, 1, figsize=(5, 6))
+    argutils.draw(ts, ax1)
+    plt.savefig(output)
 
 
 cli.add_command(simulate)

--- a/argutils/viz.py
+++ b/argutils/viz.py
@@ -1,5 +1,69 @@
 """
 Viz routines for args.
 """
+import collections
 
-# TODO port in Yan's code here.
+import tskit
+import networkx as nx
+
+
+def draw(ts, ax):
+    G = convert_nx(ts)
+    labels = {j: f"{j}" for j in range(ts.num_nodes)}
+    pos = nx_get_dot_pos(G)
+    nx.draw(
+        G,
+        pos,
+        # node_color=colour_map,
+        node_shape="o",
+        node_size=200,
+        font_size=9,
+        labels=labels,
+        ax=ax,
+    )
+
+
+def convert_nx(ts):
+    """
+    Returns the specified tree sequence as an networkx graph.
+    """
+    G = nx.Graph()
+    edges = collections.defaultdict(list)
+    for edge in ts.edges():
+        edges[(edge.child, edge.parent)].append((edge.left, edge.right))
+    for node in ts.nodes():
+        G.add_node(node.id, time=node.time, flags=node.flags)
+    for edge, intervals in edges.items():
+        G.add_edge(*edge, intervals=intervals)
+    return G
+
+
+def nx_get_dot_pos(G, add_invisibles=False):
+    """
+    Layout using graphviz's "dot" algorithm and return a dict of positions in the
+    format required by networkx. We assume that the nodes have a "time" attribute
+    """
+    nodes_at_time = collections.defaultdict(list)
+    for nd in G.nodes(data=True):
+        nodes_at_time[nd[1]["time"]].append(nd[0])
+
+    A = nx.nx_agraph.to_agraph(G)
+    # First cluster all nodes at the same times (probably mostly samples)
+    for t, nodes in nodes_at_time.items():
+        if len(nodes) > 1:
+            A.add_subgraph(nodes, level="same", name=f"cluster_t{t}")
+    if add_invisibles:
+        # Must add in "invisible" edges between different levels, to stop them clustering
+        # on the same level
+        prev_node = None
+        for t, nodes in nodes_at_time.items():
+            if prev_node is not None:
+                A.add_edge(prev_node, nodes[0], style="invis")
+            prev_node = nodes[0]
+        # We could also cluster nodes from a single individual together here
+    A.layout(prog="dot")
+    # Using negative values here as a simple way to get y coordinates going
+    # in the direction we want.
+    return {
+        n: [-float(x) for x in A.get_node(n).attr["pos"].split(",")] for n in G.nodes()
+    }


### PR DESCRIPTION
Two new things here:

1. It turns out that the resolve algorithm *is* actually simplify(keep_unary=True). I had been confused about what happens over the roots, but #61 has shown that simplify is actually doing the right thing. I haven't been able to find a counter example where it doesn't, but it must be right.
2. Put some simple infrastructure in for playing with visualisation by porting some of Yan's code. Now, running 

```
python3 -m argutils draw tmp.trees tmp.png
```
will draw a simple plot to the file. Currently it looks like this:

![tmp](https://user-images.githubusercontent.com/2664569/152686789-d55ca860-d769-4a95-aa30-f57d2bbd6e62.png)

The layout looks good (although, not clear why node 4 is at the same y value as 7 and 8 - the time is different), but there's clearly plenty that could be done. The edge information is stored in the nx Graph object, so that should be sufficient to start working out what we want to display.

Look OK as a starting point @hyanwong, @awohns?
