### PR TITLE
Add Wiuf and Hein 99 example ARG

### DIFF
--- a/argutils/ancestry.py
+++ b/argutils/ancestry.py
@@ -518,3 +518,53 @@ def resolve(tables):
     out.sort()
     out.edges.squash()
     return out.tree_sequence()
+
+
+
+def wh99_example():
+    """
+    The example ARG from figure 1 of Wiuf and Hein 99, Recombination as a Point Process
+    along Sequences. Each event is given a time increment of 1.
+    """
+    L = 7
+    # FIXME using this as a way to experiement with encoding. Remove once decided.
+    left = -math.inf
+    right = math.inf
+    tables = tskit.TableCollection(L)
+    t = 0
+    for _ in range(3):
+        tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, time=t)
+
+    def re(child, x):
+        nonlocal t
+        t += 1
+        left_parent = tables.nodes.add_row(time=t)
+        right_parent = tables.nodes.add_row(time=t)
+        tables.edges.add_row(left, x, left_parent, child)
+        tables.edges.add_row(x, right, right_parent, child)
+
+    def ca(*args):
+        nonlocal t
+        t += 1
+        parent = tables.nodes.add_row(time=t)
+        for child in args:
+            tables.edges.add_row(left, right, parent, child)
+
+    re(1, x=4)
+    re(2, x=2)
+    ca(0, 3)
+    re(5, x=5)
+    ca(4, 8)
+    re(10, x=3)
+    ca(12, 9)
+    ca(7, 11)
+    re(13, x=6)
+    ca(16, 6)
+    ca(14, 15)
+    re(18, x=1)
+    ca(20, 17)
+    ca(19, 21)
+
+    return tables
+
+

--- a/argutils/tests.py
+++ b/argutils/tests.py
@@ -120,6 +120,28 @@ class TestResolve:
         # print(resolved.draw_text())
         assert resolved.equals(resolved2)
 
+    def test_resolve_equal_to_simplify_wh99(self):
+        tables = argutils.wh99_example()
+        ts1 = argutils.resolve(tables)
+        left = tables.edges.left
+        left[left == -np.inf] = 0
+        right = tables.edges.right
+        right[right == np.inf] = tables.sequence_length
+        tables.edges.left = left
+        tables.edges.right = right
+        tables.sort()
+        tables.simplify(keep_unary=True)
+        ts2 = tables.tree_sequence()
+        # This is *really* nasty, but there's a fundamental issue with the wh99
+        # ARG. Node 9 has no ancestral material going through it, which simplify
+        # really doesn't want to include. So the topologies we get back are equal
+        # but the local version still has node 9 included. Until we figure out
+        # what the semantics should be here (probably simplify is doing the
+        # right thing) this is the easiest thing to do.
+        s1 = ts1.draw_text(node_labels={})
+        s2 = ts2.draw_text(node_labels={})
+        assert s1 == s2
+
     @pytest.mark.parametrize("seed", range(90, 100))
     @pytest.mark.parametrize(
         ["n", "L"],


### PR DESCRIPTION
Adds the Wiuf and Hein 99 example ARG mentioned in #56.

The draw method currently produces this:

![wh99](https://user-images.githubusercontent.com/2664569/152798770-ba8aa172-776b-42f5-9ebd-cb016ba0ccf1.png)

Here are the trees:
```
14.00┊  22   ┊  22   ┊  22   ┊    22  ┊  22    ┊
     ┊   ┃   ┊   ┃   ┊   ┃   ┊     ┃  ┊   ┃    ┊
13.00┊   ┃   ┊  21   ┊  21   ┊    21  ┊  21    ┊
     ┊   ┃   ┊   ┃   ┊  ┏┻━┓ ┊   ┏━┻┓ ┊ ┏━┻━┓  ┊
12.00┊  19   ┊  20   ┊ 20  ┃ ┊  20  ┃ ┊ 20  ┃  ┊
     ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊   ┃  ┃ ┊ ┃   ┃  ┊
11.00┊  18   ┊  18   ┊ 18  ┃ ┊  18  ┃ ┊ 18  ┃  ┊
     ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊ ┏━┻┓ ┃ ┊ ┃   ┃  ┊
10.00┊   ┃   ┊   ┃   ┊  ┃ 17 ┊ ┃  ┃17 ┊ ┃  17  ┊
     ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┏┻┓ ┊
9.00 ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊ ┃ 15 ┃ ┊ ┃ 16 ┃ ┊
     ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
8.00 ┊  14   ┊  14   ┊ 14  ┃ ┊ 14 ┃ ┃ ┊ 14 ┃ ┃ ┊
     ┊  ┏┻━┓ ┊  ┏┻━┓ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
7.00 ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃ 13 ┃ ┊ ┃ 13 ┃ ┊
     ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
6.00 ┊  ┃ 11 ┊  ┃ 11 ┊  ┃  ┃ ┊ ┃ 12 ┃ ┊ ┃ 12 ┃ ┊
     ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
5.00 ┊  ┃ 10 ┊  ┃ 10 ┊  ┃  ┃ ┊ ┃ 10 ┃ ┊ ┃ 10 ┃ ┊
     ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
4.00 ┊  ┃  8 ┊  ┃  8 ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
     ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
3.00 ┊  7  ┃ ┊  7  ┃ ┊  7  ┃ ┊ 7  ┃ ┃ ┊ 7  ┃ ┃ ┊
     ┊ ┏┻┓ ┃ ┊ ┏┻┓ ┃ ┊ ┏┻┓ ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
2.00 ┊ ┃ ┃ 5 ┊ ┃ ┃ 5 ┊ ┃ ┃ 6 ┊ ┃  ┃ 6 ┊ ┃  ┃ 6 ┊
     ┊ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
1.00 ┊ ┃ 3 ┃ ┊ ┃ 3 ┃ ┊ ┃ 3 ┃ ┊ ┃  4 ┃ ┊ ┃  4 ┃ ┊
     ┊ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
0.00 ┊ 0 1 2 ┊ 0 1 2 ┊ 0 1 2 ┊ 0  1 2 ┊ 0  1 2 ┊
     0       1       2       4        6        7
```

Note node 9 is just sitting there, and doesn't appear in the trees. This is because its on a non-ancestral path. I had to do some trickery here because the local resolve method keeps this node, whereas simplify is quite intent on removing it.