### PR TITLE
Change to (0,L) for ARG boundaries

### DIFF
--- a/argutils/tests.py
+++ b/argutils/tests.py
@@ -1,5 +1,4 @@
 # Run using python3 -m pytest argutils/tests.py
-import math
 
 import tskit
 import pytest
@@ -55,8 +54,8 @@ class TestSimulate:
 
 
 def gmrca_example_resolved():
-    # 3.00┊     ┊  5  ┊
-    #     ┊     ┊ ┏┻┓ ┊
+    # 3.00┊  5  ┊  5  ┊
+    #     ┊  ┃  ┊ ┏┻┓ ┊
     # 2.00┊  4  ┊ 4 ┃ ┊
     #     ┊ ┏┻┓ ┊ ┃ ┃ ┊
     # 1.00┊ ┃ 2 ┊ ┃ 3 ┊
@@ -99,12 +98,12 @@ def gmrca_example_unresolved():
     tables.nodes.add_row(time=2)
     tables.nodes.add_row(time=3)
 
-    tables.edges.add_row(-math.inf, 1, 2, 1)
-    tables.edges.add_row(1, math.inf, 3, 1)
-    tables.edges.add_row(-math.inf, math.inf, 4, 0)
-    tables.edges.add_row(-math.inf, math.inf, 5, 4)
-    tables.edges.add_row(-math.inf, math.inf, 4, 2)
-    tables.edges.add_row(-math.inf, math.inf, 5, 3)
+    tables.edges.add_row(0, 1, 2, 1)
+    tables.edges.add_row(1, 2, 3, 1)
+    tables.edges.add_row(0, 2, 4, 0)
+    tables.edges.add_row(0, 2, 5, 4)
+    tables.edges.add_row(0, 2, 4, 2)
+    tables.edges.add_row(0, 2, 5, 3)
     return tables
 
 
@@ -115,20 +114,13 @@ class TestResolve:
     )
     def test_examples(self, unresolved, resolved):
         resolved2 = argutils.resolve(unresolved)
-        # printt ()
-        # print(resolved.draw_text())
+        # print()
         # print(resolved.draw_text())
         assert resolved.equals(resolved2)
 
     def test_resolve_equal_to_simplify_wh99(self):
         tables = argutils.wh99_example()
         ts1 = argutils.resolve(tables)
-        left = tables.edges.left
-        left[left == -np.inf] = 0
-        right = tables.edges.right
-        right[right == np.inf] = tables.sequence_length
-        tables.edges.left = left
-        tables.edges.right = right
         tables.sort()
         tables.simplify(keep_unary=True)
         ts2 = tables.tree_sequence()
@@ -160,12 +152,6 @@ class TestResolve:
         rho = 0.1
         tables = argutils.sim_coalescent(n, L=L, rho=rho, seed=seed, resolved=False)
         ts1 = argutils.resolve(tables)
-        left = tables.edges.left
-        left[left == -np.inf] = 0
-        right = tables.edges.right
-        right[right == np.inf] = tables.sequence_length
-        tables.edges.left = left
-        tables.edges.right = right
         tables.sort()
         tables.simplify(keep_unary=True)
         tables.assert_equals(ts1.tables, ignore_provenance=True)


### PR DESCRIPTION
This changes the encoding for the "implicit" ARG to use (0, L) instread of +/- infinity, and thereby making the descriptions a valid tree sequence. This works really well, I think. Consider the trees we get when we draw the wh99 example:
```
14.00┊           22         ┊              22      ┊              22      ┊              22      ┊              22      ┊              22      ┊              22      ┊
     ┊       ┏━━━━┻━━━━┓    ┊           ┏━━━┻━━━━┓ ┊           ┏━━━┻━━━━┓ ┊           ┏━━━┻━━━━┓ ┊           ┏━━━┻━━━━┓ ┊           ┏━━━┻━━━━┓ ┊           ┏━━━┻━━━━┓ ┊
13.00┊       ┃        21    ┊          21        ┃ ┊          21        ┃ ┊          21        ┃ ┊          21        ┃ ┊          21        ┃ ┊          21        ┃ ┊
     ┊       ┃       ┏━┻━━┓ ┊       ┏━━━┻━━━┓    ┃ ┊       ┏━━━┻━━━┓    ┃ ┊       ┏━━━┻━━━┓    ┃ ┊       ┏━━━┻━━━┓    ┃ ┊       ┏━━━┻━━━┓    ┃ ┊       ┏━━━┻━━━┓    ┃ ┊
12.00┊      19       ┃   20 ┊      20       ┃   19 ┊      20       ┃   19 ┊      20       ┃   19 ┊      20       ┃   19 ┊      20       ┃   19 ┊      20       ┃   19 ┊
     ┊       ┃       ┃      ┊       ┃       ┃      ┊       ┃       ┃      ┊       ┃       ┃      ┊       ┃       ┃      ┊       ┃       ┃      ┊       ┃       ┃      ┊
11.00┊      18       ┃      ┊      18       ┃      ┊      18       ┃      ┊      18       ┃      ┊      18       ┃      ┊      18       ┃      ┊      18       ┃      ┊
     ┊    ┏━━┻━━━┓   ┃      ┊    ┏━━┻━━━┓   ┃      ┊    ┏━━┻━━━┓   ┃      ┊    ┏━━┻━━━┓   ┃      ┊    ┏━━┻━━━┓   ┃      ┊    ┏━━┻━━━┓   ┃      ┊    ┏━━┻━┓     ┃      ┊
10.00┊    ┃      ┃  17      ┊    ┃      ┃  17      ┊    ┃      ┃  17      ┊    ┃      ┃  17      ┊    ┃      ┃  17      ┊    ┃      ┃  17      ┊    ┃    ┃    17      ┊
     ┊    ┃      ┃  ┏┻━┓    ┊    ┃      ┃  ┏┻━┓    ┊    ┃      ┃  ┏┻━┓    ┊    ┃      ┃  ┏┻━┓    ┊    ┃      ┃  ┏┻━┓    ┊    ┃      ┃  ┏┻━┓    ┊    ┃    ┃   ┏━┻━┓    ┊
9.00 ┊    ┃     15  ┃ 16    ┊    ┃     15  ┃ 16    ┊    ┃     15  ┃ 16    ┊    ┃     15  ┃ 16    ┊    ┃     15  ┃ 16    ┊    ┃     15  ┃ 16    ┊    ┃   15  16   ┃    ┊
     ┊    ┃      ┃  ┃       ┊    ┃      ┃  ┃       ┊    ┃      ┃  ┃       ┊    ┃      ┃  ┃       ┊    ┃      ┃  ┃       ┊    ┃      ┃  ┃       ┊    ┃        ┃   ┃    ┊
8.00 ┊   14      ┃  ┃       ┊   14      ┃  ┃       ┊   14      ┃  ┃       ┊   14      ┃  ┃       ┊   14      ┃  ┃       ┊   14      ┃  ┃       ┊   14        ┃   ┃    ┊
     ┊  ┏━┻━┓    ┃  ┃       ┊  ┏━┻━┓    ┃  ┃       ┊  ┏━┻━┓    ┃  ┃       ┊  ┏━┻━┓    ┃  ┃       ┊  ┏━┻━┓    ┃  ┃       ┊  ┏━┻━┓    ┃  ┃       ┊  ┏━┻━┓      ┃   ┃    ┊
7.00 ┊  ┃   ┃   13  ┃       ┊  ┃   ┃   13  ┃       ┊  ┃   ┃   13  ┃       ┊  ┃   ┃   13  ┃       ┊  ┃   ┃   13  ┃       ┊  ┃   ┃   13  ┃       ┊  ┃   ┃     13   ┃    ┊
     ┊  ┃   ┃  ┏━┻┓ ┃       ┊  ┃   ┃  ┏━┻┓ ┃       ┊  ┃   ┃  ┏━┻┓ ┃       ┊  ┃   ┃  ┏━┻┓ ┃       ┊  ┃   ┃  ┏━┻┓ ┃       ┊  ┃   ┃  ┏━┻┓ ┃       ┊  ┃   ┃     ┏┻━┓ ┃    ┊
6.00 ┊  ┃  11  ┃ 12 ┃       ┊  ┃  11  ┃ 12 ┃       ┊  ┃  11  ┃ 12 ┃       ┊  ┃  11 12  ┃ ┃       ┊  ┃  11 12  ┃ ┃       ┊  ┃  11 12  ┃ ┃       ┊  ┃  11    12  ┃ ┃    ┊
     ┊  ┃   ┃  ┃    ┃       ┊  ┃   ┃  ┃    ┃       ┊  ┃   ┃  ┃    ┃       ┊  ┃      ┃  ┃ ┃       ┊  ┃      ┃  ┃ ┃       ┊  ┃      ┃  ┃ ┃       ┊  ┃         ┃  ┃ ┃    ┊
5.00 ┊  ┃  10  ┃    ┃       ┊  ┃  10  ┃    ┃       ┊  ┃  10  ┃    ┃       ┊  ┃     10  ┃ ┃       ┊  ┃     10  ┃ ┃       ┊  ┃     10  ┃ ┃       ┊  ┃        10  ┃ ┃    ┊
     ┊  ┃  ┏┻┓ ┃    ┃       ┊  ┃  ┏┻┓ ┃    ┃       ┊  ┃  ┏┻┓ ┃    ┃       ┊  ┃     ┏┻┓ ┃ ┃       ┊  ┃     ┏┻┓ ┃ ┃       ┊  ┃     ┏┻┓ ┃ ┃       ┊  ┃        ┏┻┓ ┃ ┃    ┊
4.00 ┊  ┃  8 ┃ 9    ┃       ┊  ┃  8 ┃ 9    ┃       ┊  ┃  ┃ 8 9    ┃       ┊  ┃     ┃ 8 9 ┃       ┊  ┃     ┃ 8 9 ┃       ┊  ┃     ┃ 8 9 ┃       ┊  ┃        ┃ 8 9 ┃    ┊
     ┊  ┃  ┃ ┃      ┃       ┊  ┃  ┃ ┃      ┃       ┊  ┃  ┃ ┃      ┃       ┊  ┃     ┃ ┃   ┃       ┊  ┃     ┃ ┃   ┃       ┊  ┃     ┃   ┃ ┃       ┊  ┃        ┃   ┃ ┃    ┊
3.00 ┊  7  ┃ ┃      ┃       ┊  7  ┃ ┃      ┃       ┊  7  ┃ ┃      ┃       ┊  7     ┃ ┃   ┃       ┊  7     ┃ ┃   ┃       ┊  7     ┃   ┃ ┃       ┊  7        ┃   ┃ ┃    ┊
     ┊ ┏┻┓ ┃ ┃      ┃       ┊ ┏┻┓ ┃ ┃      ┃       ┊ ┏┻┓ ┃ ┃      ┃       ┊ ┏┻┓    ┃ ┃   ┃       ┊ ┏┻┓    ┃ ┃   ┃       ┊ ┏┻┓    ┃   ┃ ┃       ┊ ┏┻┓       ┃   ┃ ┃    ┊
2.00 ┊ ┃ ┃ 5 ┃      6       ┊ ┃ ┃ 5 ┃      6       ┊ ┃ ┃ ┃ 5      6       ┊ ┃ ┃    ┃ 5   6       ┊ ┃ ┃    ┃ 5   6       ┊ ┃ ┃    ┃   5 6       ┊ ┃ ┃       ┃   5 6    ┊
     ┊ ┃ ┃ ┃ ┃              ┊ ┃ ┃ ┃ ┃              ┊ ┃ ┃ ┃        ┃       ┊ ┃ ┃    ┃     ┃       ┊ ┃ ┃    ┃     ┃       ┊ ┃ ┃    ┃     ┃       ┊ ┃ ┃       ┃     ┃    ┊
1.00 ┊ ┃ 3 ┃ 4              ┊ ┃ 3 ┃ 4              ┊ ┃ 3 4        ┃       ┊ ┃ 3    4     ┃       ┊ ┃ 3    4     ┃       ┊ ┃ 3    4     ┃       ┊ ┃ 3       4     ┃    ┊
     ┊ ┃ ┃ ┃                ┊ ┃ ┃ ┃                ┊ ┃ ┃          ┃       ┊ ┃ ┃          ┃       ┊ ┃      ┃     ┃       ┊ ┃      ┃     ┃       ┊ ┃         ┃     ┃    ┊
0.00 ┊ 0 1 2                ┊ 0 1 2                ┊ 0 1          2       ┊ 0 1          2       ┊ 0      1     2       ┊ 0      1     2       ┊ 0         1     2    ┊
     0                      1                      2                      3                      4                      5                      6                      7
```

Compare this to what we get when we resolve/simplify/whatever:
```
14.00┊  22   ┊  22   ┊  22   ┊    22  ┊  22    ┊
     ┊   ┃   ┊   ┃   ┊   ┃   ┊     ┃  ┊   ┃    ┊
13.00┊   ┃   ┊  21   ┊  21   ┊    21  ┊  21    ┊
     ┊   ┃   ┊   ┃   ┊  ┏┻━┓ ┊   ┏━┻┓ ┊ ┏━┻━┓  ┊
12.00┊  19   ┊  20   ┊ 20  ┃ ┊  20  ┃ ┊ 20  ┃  ┊
     ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊   ┃  ┃ ┊ ┃   ┃  ┊
11.00┊  18   ┊  18   ┊ 18  ┃ ┊  18  ┃ ┊ 18  ┃  ┊
     ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊ ┏━┻┓ ┃ ┊ ┃   ┃  ┊
10.00┊   ┃   ┊   ┃   ┊  ┃ 17 ┊ ┃  ┃17 ┊ ┃  17  ┊
     ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┏┻┓ ┊
9.00 ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊ ┃ 15 ┃ ┊ ┃ 16 ┃ ┊
     ┊   ┃   ┊   ┃   ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
8.00 ┊  14   ┊  14   ┊ 14  ┃ ┊ 14 ┃ ┃ ┊ 14 ┃ ┃ ┊
     ┊  ┏┻━┓ ┊  ┏┻━┓ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
7.00 ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃ 13 ┃ ┊ ┃ 13 ┃ ┊
     ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
6.00 ┊  ┃ 11 ┊  ┃ 11 ┊  ┃  ┃ ┊ ┃ 12 ┃ ┊ ┃ 12 ┃ ┊
     ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
5.00 ┊  ┃ 10 ┊  ┃ 10 ┊  ┃  ┃ ┊ ┃ 10 ┃ ┊ ┃ 10 ┃ ┊
     ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
4.00 ┊  ┃  8 ┊  ┃  8 ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
     ┊  ┃  ┃ ┊  ┃  ┃ ┊  ┃  ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
3.00 ┊  7  ┃ ┊  7  ┃ ┊  7  ┃ ┊ 7  ┃ ┃ ┊ 7  ┃ ┃ ┊
     ┊ ┏┻┓ ┃ ┊ ┏┻┓ ┃ ┊ ┏┻┓ ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
2.00 ┊ ┃ ┃ 5 ┊ ┃ ┃ 5 ┊ ┃ ┃ 6 ┊ ┃  ┃ 6 ┊ ┃  ┃ 6 ┊
     ┊ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
1.00 ┊ ┃ 3 ┃ ┊ ┃ 3 ┃ ┊ ┃ 3 ┃ ┊ ┃  4 ┃ ┊ ┃  4 ┃ ┊
     ┊ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┊ ┃ ┃ ┃ ┊ ┃  ┃ ┃ ┊ ┃  ┃ ┃ ┊
0.00 ┊ 0 1 2 ┊ 0 1 2 ┊ 0 1 2 ┊ 0  1 2 ┊ 0  1 2 ┊
     0       1       2       4        6        7
```

I think it's clear the process *is* equivalent to simplifying a forwards-time tree sequence, which is nice.