### PR TITLE
Return positions from draw, and allow positions to be specified

### DIFF
--- a/argutils/viz.py
+++ b/argutils/viz.py
@@ -8,8 +8,12 @@ import networkx as nx
 import numpy as np
 import string
 
-def draw(ts, ax, use_ranked_times=None, tweak_x=None, arrows=False):
+def draw(ts, ax, use_ranked_times=None, tweak_x=None, arrows=False, pos=None):
     """
+    Draw a graphical representation of a tree sequence. If a metadata key
+    called "name" exists for the node, it is taken as
+    a node label, otherwise the node ID will be used as a label instead.
+
     If use_ranked times is True, the y axis uses the time ranks, with the
     same times sharing a rank. If False, it uses the true (tree sequence)
     times. If None, times from the tree sequence are not used and the
@@ -19,8 +23,8 @@ def draw(ts, ax, use_ranked_times=None, tweak_x=None, arrows=False):
     the x position of node u to be hand-adjusted by adding or
     subtracting a percentage of the total x width of the plot
     
-    If a metadata key called "name" exists for the node, it is taken as
-    a node label, otherwise the node ID will be used as a label instead.
+    If pos is passed in, it should be a dictionary mapping nodes to
+    positions.
     """
     G = convert_nx(ts)
     labels = {}
@@ -30,7 +34,9 @@ def draw(ts, ax, use_ranked_times=None, tweak_x=None, arrows=False):
         except (TypeError, KeyError):
             labels[nd.id] = str(nd.id)
 
-    pos = nx_get_dot_pos(G)
+    if pos is None:
+        pos = nx_get_dot_pos(G)
+
     if use_ranked_times is not None:
         if use_ranked_times:
             _, inv = np.unique(ts.tables.nodes.time, return_inverse=True)
@@ -66,6 +72,7 @@ def draw(ts, ax, use_ranked_times=None, tweak_x=None, arrows=False):
         ax=ax,
     )
 
+    return pos
 
 def label_nodes(ts, labels=None):
     """


### PR DESCRIPTION
This allows us to place nodes in the same position in adjacent plots. It could also act as a workaround for #75 as we could output the positions and then hard code them. Here's how we could do the former:

```
ts = argutils.sim_coalescent(4, 0.001, 1000, seed=123)
print(f"{ts.num_samples} samples, {ts.num_trees} trees")
fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(20,10))
pos = argutils.viz.draw(ts, ax1, use_ranked_times=True, tweak_x={24: 15, 23: 5, 22: 10, 21: 10})
new_ts, node_map = ts.simplify(map_nodes=True)
_ = argutils.viz.draw(new_ts, ax2, pos={node_map[i]:p  for i, p in pos.items()})
```
![image](https://user-images.githubusercontent.com/4699014/153034647-ac217c22-eed1-4bd9-b4b1-e868c7e8b862.png)

