### PR TITLE
Implement 3 new types of simplification

### DIFF
--- a/argutils/tests.py
+++ b/argutils/tests.py
@@ -1,4 +1,6 @@
 # Run using python3 -m pytest argutils/tests.py
+import collections
+import string
 
 import tskit
 import pytest
@@ -131,3 +133,97 @@ class TestResolve:
         # print()
         # print(resolved.draw_text())
         assert resolved.equals(resolved2, ignore_provenance=True)
+
+class TestLabels:
+    def test_viz_label_nodes_many(self):
+        ts = argutils.sim_coalescent(20, 0.1, 10, seed=123) # over 26 nodes
+        ts = argutils.viz.label_nodes(ts)
+        assert ts.num_nodes > len(string.ascii_uppercase)
+        i = 0
+        for c in string.ascii_uppercase:
+            assert ts.node(i).metadata["name"] == c
+            i += 1
+        while i < ts.num_nodes:
+            assert ts.node(i).metadata["name"] == i
+            i += 1
+
+    def test_viz_label_nodes_bespoke(self):
+        ts = argutils.sim_coalescent(20, 0.1, 10, seed=123) # over 26 nodes
+        ts = argutils.viz.label_nodes(
+            ts, labels={n: str(i) for n, i in enumerate(range(ts.num_nodes, 0, -1))})
+        for nd in ts.nodes():
+            assert nd.metadata["name"] == f"{ts.num_nodes - nd.id}"
+    
+
+class TestSimplifyFunctions:
+    def test_simplify_keeping_all_nodes(self):
+        ts = argutils.viz.label_nodes(argutils.wh99_example())
+        ts2 = argutils.simplify_keeping_all_nodes(ts)
+        assert ts.num_edges > ts2.num_edges
+        assert ts.num_nodes == ts2.num_nodes
+        for n1, n2 in zip(ts.nodes(), ts2.nodes()):
+            assert "name" in n1.metadata and n1.metadata["name"]
+            assert n1.metadata["name"] == n2.metadata["name"]
+
+    def test_simplify_remove_pass_through(self):
+        ts = argutils.sim_coalescent(10, 0.1, 10, seed=3)
+        node_edges = np.zeros((ts.num_nodes, 2), dtype=int)
+        has_pass_through = False
+        for e in ts.edges():
+            node_edges[e.child][0] += 1
+            node_edges[e.parent][1] += 1
+        # at least one node with 1 parent and 1 child only
+        for row in node_edges:
+            if list(row) == [1, 1]:
+                has_pass_through = True
+        assert has_pass_through
+
+        # This example has a diamond, so a single pass of the remove_pass_through
+        # algorithm won't remove the top of the diamon
+        ts2 = argutils.simplify_remove_pass_through(ts, repeat=False)
+        node_edges = np.zeros((ts.num_nodes, 2), dtype=int)
+        has_pass_through = False
+        for e in ts.edges():
+            node_edges[e.child][0] += 1
+            node_edges[e.parent][1] += 1
+        # still at least one node with 1 parent and 1 child only
+        for row in node_edges:
+            if list(row) == [1, 1]:
+                has_pass_through = True
+        assert has_pass_through
+        
+
+        ts3 = argutils.simplify_remove_pass_through(ts, repeat=True)
+        node_edges = np.zeros((ts.num_nodes, 2), dtype=int)
+        for e in ts3.edges():
+            node_edges[e.child][0] += 1
+            node_edges[e.parent][1] += 1
+        for i, row in enumerate(node_edges):
+            # No more pass thoguh nodes left
+            assert list(row) != [1, 1]
+        
+        
+    def test_simplify_keeping_unary_in_coal(self):
+        for ts in [
+            argutils.wh99_example(),
+            argutils.sim_wright_fisher(4, N=10, L=5, seed=1),
+            argutils.sim_coalescent(10, 0.1, 10, seed=3),
+        ]:
+            ts2 = argutils.simplify_keeping_unary_in_coal(ts)
+            ts3 = ts.simplify()
+            assert ts2.num_nodes == ts3.num_nodes
+            has_unary = False
+            for tree in ts2.trees():
+                for n in tree.nodes():
+                    if tree.num_children(n) == 1:
+                        has_unary = True
+            assert has_unary
+            assert ts2.num_individuals == ts.num_individuals
+            
+            has_unary = False
+            for tree in ts3.trees():
+                for n in tree.nodes():
+                    if tree.num_children(n) == 1:
+                        has_unary = True
+            assert not has_unary
+            


### PR DESCRIPTION
Implement `test_simplify_keeping_all_nodes`, `simplify_remove_pass_through` (with option to repeatedly apply until no pass through nodes remain), and tidy up test_simplify_keeping_unary_in_coal so that it runs OK on tree sequences with individuals already present (e.g. for WF simulations).

The `simplify_remove_pass_through` function turned out to be a bit tricky. I think I have it right though, and there are tests for all this.