### PR TITLE
Use W-F simulator for fig 5

### DIFF
--- a/illustrations/ARG_recomb_node_deletion.py
+++ b/illustrations/ARG_recomb_node_deletion.py
@@ -2,112 +2,91 @@ import collections
 import io
 import itertools
 import sys
+import string
 from pathlib import Path
 
-
-import msprime
-import networkx as nx
+import matplotlib as mpl
+import matplotlib.pyplot as plt
 import numpy as np
 import tskit
-import matplotlib.pyplot as plt
+
+current_dir = Path(__file__).parent
+
+# useful modules in the top level dir: we should be able to import this if the script is
+# run from the top level dir, but for some reason it fails, so we just add the path here
+sys.path.append(str(current_dir.parent.absolute()))
+import argutils
 
 outfile = "ARG_recomb_node_deletion"
 
-# useful scripts in the top level dir
-sys.path.append(str(Path(__file__).parent.parent.absolute() / "utils"))
-import convert
-import ts_process
-import argdraw
+def arg_node_simplification():
+    seed = 372
+    t_x={9: 3, 6: -8, 18: 50, 19: -15, 17: 5, 13: 10, 14: 2, 10: -10, 15: 5, 16: -5, 7: -5, 11: 5, 8: 8}
 
-
-def positions_from_ts(ts, pos=None, return_graph=False):
-    ts_arg = ts_process.flag_unary_nodes(ts)
-    G = ts_process.to_networkx_graph(ts_arg)
-    if pos is None:
-        pos = argdraw.nx_get_dot_pos(G, add_invisibles=False)
-    return (pos, G) if return_graph else pos
+    ts = argutils.sim_wright_fisher(2, 10, 100, recomb_proba=0.1, seed=seed)
+    labels = {i: string.ascii_uppercase[i] for i in range(len(string.ascii_uppercase))}
+    # relabel the nodes to get samples reading A B C D
+    labels.update({2: 'B', 3: 'C', 1: "D"})
+    ts = argutils.viz.label_nodes(ts, labels)
     
-
-def plot_ts_arg(ts, ax, labels=None, pos=None, arrows=False):
-    pos, G = positions_from_ts(ts, pos, return_graph=True)
-    col_map = argdraw.nx_ts_colour_map(G)
-
-    argdraw.nx_draw_with_curved_multi_edges(
-        G, pos, col_map, curve_scale=30, ax=ax, labels=labels)
-
-# SIMULATE
-ts = ts_process.convert_to_single_rec_node(
-    msprime.sim_ancestry(
-        3,
-        sequence_length=1e4,
-        population_size=1e4,
-        recombination_rate=1e-8,
-        record_full_arg=True, 
-        random_seed=76, # by trial and error, a seed of 76 gives a nice small example
+    fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4, figsize=(12,5))
+    ax1.set_title("(a) little ARG")
+    ax2.set_title("(b) remove pass through")
+    ax3.set_title("(c) simplify (keep unary in coal)")
+    ax4.set_title("(d) fully simplified")
+    col = mpl.colors.to_hex(plt.cm.tab20(1))
+    pos = argutils.viz.draw(
+        ts, ax1,
+        draw_edge_widths=True,
+        use_ranked_times=True, node_color=col, tweak_x=t_x)
+    ts2, node_map = argutils.simplify_remove_pass_through(ts, repeat=True, map_nodes=True)
+    argutils.viz.draw(
+        ts2, ax2,
+        draw_edge_widths=True,
+        pos={node_map[i]: p for i, p in pos.items()}, node_color=col)
+    ts3, node_map = argutils.simplify_keeping_unary_in_coal(ts, map_nodes=True)
+    argutils.viz.draw(
+        ts3, ax3,
+        draw_edge_widths=True,
+        pos={node_map[i]: p for i, p in pos.items()}, node_color=col)
+    ts4, node_map = ts.simplify(map_nodes=True)
+    argutils.viz.draw(
+        ts4, ax4,
+        draw_edge_widths=True,
+        pos={node_map[i]: p for i, p in pos.items()}, node_color=col)
+    
+    
+    graph1_io = io.StringIO()
+    plt.savefig(graph1_io, format="svg", bbox_inches='tight')
+    graph1_svg = graph1_io.getvalue()
+    graph1_svg = graph1_svg[graph1_svg.find("<svg"):]
+    
+    tree_svg = ts.draw_svg(
+        size=(970, 250),
+        time_scale="rank",
+        node_labels=labels,
+        style=".x-axis .tick .lab {font-weight: regular; font-size: 12}"
     )
-)
 
-node_pos = positions_from_ts(ts)
+    # figlabelstyle = 'font-family="serif" font-size="30px"'
 
-# relabel the nodes to get the order right
-tables = ts.dump_tables()
-node_map = np.arange(ts.num_nodes, dtype=tables.edges.parent.dtype)
-sample_ids = ts.samples()
-assert np.all(sample_ids == np.arange(ts.num_samples))
-node_map[np.argsort([node_pos[s][0] for s in sample_ids])] = sample_ids
-tables.nodes.clear()
-for u in node_map:
-    tables.nodes.append(ts.tables.nodes[u])
-tables.edges.parent = node_map[tables.edges.parent]
-tables.edges.child = node_map[tables.edges.child]
-tables.sort()
-ts=tables.tree_sequence()
-
-# Get the positions again, as the nodes are now if a different order
-node_pos = positions_from_ts(ts)
-
-ts_simp, node_map = ts.simplify(map_nodes=True)
-labels = {j: i for i, j in enumerate(node_map) if j>=0}
-
-# tweak some node positions for this example
-node_pos[22][0] *= 1.05
-node_pos[11][0] *= 0.9
-
-simp_node_pos = {j:node_pos[i] for i, j in enumerate(node_map) if j>=0}
-fig, ax1 = plt.subplots(1, 1, figsize=(5, 6))
-plot_ts_arg(ts, ax1, pos=node_pos)
-graph1_io = io.StringIO()
-plt.savefig(graph1_io, format="svg", bbox_inches='tight')
-graph1_svg = graph1_io.getvalue()
-graph1_svg = graph1_svg[graph1_svg.find("<svg"):]
-
-fig, ax2 = plt.subplots(1, 1, figsize=(5, 6))
-plot_ts_arg(ts_simp, ax2, labels=labels, pos=simp_node_pos)
-graph2_io = io.StringIO()
-plt.savefig(graph2_io, format="svg", bbox_inches='tight')
-graph2_svg = graph2_io.getvalue()
-graph2_svg = graph2_svg[graph2_svg.find("<svg"):]
-
-tree_svg = ts_simp.draw_svg(
-    size=(900, 200),
-    time_scale="rank",
-    node_labels=labels,
-    style=".x-axis .tick .lab {font-weight: regular; font-size: 12}"
-)
-
-with open(Path(__file__).parent / (outfile + ".svg"), "wt") as file:
-    figlabelstyle = 'font-family="serif" font-size="30px"'
-    print(
-        '<svg baseProfile="full" height="700" version="1.1" width="920"',
-        'xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events"',
+    svg = [
+        '<svg width="900" height="700" xmlns="http://www.w3.org/2000/svg" '
         'xmlns:xlink="http://www.w3.org/1999/xlink">',
-        file=file)
-    print(
-        '<g transform="translate(40 0)">' + graph1_svg + '</g>',
-        f'<g transform="translate(20 30)"><text {figlabelstyle}>a</text></g>',
-        '<g transform="translate(500 0)">' + graph2_svg + '</g>',
-        f'<g transform="translate(480 30)"><text {figlabelstyle}>b</text></g>',
-        '<g transform="translate(0 500)">' + tree_svg + '</g>',
-        f'<g transform="translate(20 490)"><text {figlabelstyle}>c</text></g>',
-        file=file)
-    print('</svg>', file=file)
+        '<style>.tree-sequence text {font-family: sans-serif}</style>'
+        '<g transform="translate(10, 50)">',
+    ]
+    svg.append('<g transform="scale(0.87)">' + graph1_svg + "</g>")
+    svg.append('<g transform="translate(0 400) scale(0.83)">' + tree_svg + "</g>")
+    svg.append("</g></svg>")
+    return "\n".join(svg)
+
+
+svg = (
+    '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" '
+    '"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n'
+)
+svg += arg_node_simplification()
+with open(current_dir / f"{outfile}.svg", "wt") as f:
+    f.write(svg)
+    


### PR DESCRIPTION
See https://github.com/tskit-dev/what-is-an-arg-paper/issues/82#issuecomment-1039268250

There's an interesting case here where in (c) we haven't removed the ARG nodes in which multiple lines come together (i.e. node `I`).

~Annoyingly, I just realised, however, that this *doesn't* have any nodes that are both recombination and ca/coalescence nodes (apart from `J` which gets simplified away), so I might need to hunt for another example.~ Actually, node `E` is one of the 2 nodes that contribute to a "recombinant" and also a coalescent node. But maybe we want an example where a node is both a coalescent node and a *recombinant*.

<img width="821" alt="Screenshot 2022-02-14 at 19 04 29" src="https://user-images.githubusercontent.com/4699014/153929334-5af5da34-e3ef-4a8f-87d7-44cd69f6ddc8.png">

