### PR TITLE
Add labels to pedigree

### DIFF
--- a/illustrations/assets/pedigree.svg
+++ b/illustrations/assets/pedigree.svg
@@ -25,8 +25,8 @@
      showgrid="false"
      inkscape:snap-object-midpoints="true"
      inkscape:zoom="0.8662255"
-     inkscape:cx="307.65661"
-     inkscape:cy="-1387.0522"
+     inkscape:cx="165.08403"
+     inkscape:cy="693.2375"
      inkscape:window-width="1396"
      inkscape:window-height="847"
      inkscape:window-x="44"
@@ -979,6 +979,54 @@
            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.05556px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.264583"
            x="138.48286"
            y="227.84328">(0,7]</tspan></text>
+    </g>
+    <g
+       id="g8620-6-7-1-2-2-1-4-9"
+       transform="translate(-3.3828082,-9.3051481)">
+      <rect
+         style="fill:#ffffff;stroke-width:0.799999;stroke-linecap:round;paint-order:markers fill stroke"
+         id="rect4791-6-4-5-0-9-8-1-3"
+         width="22.771273"
+         height="8.9705019"
+         x="137.21416"
+         y="221.91898"
+         ry="3.3172145"
+         rx="3.2101941" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#373737;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="139.54118"
+         y="227.84328"
+         id="text3241-7-4-5-7-7-7-6-8"><tspan
+           sodipodi:role="line"
+           id="tspan3239-8-9-5-4-5-1-1-0"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05556px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#373737;fill-opacity:1;stroke-width:0.264583"
+           x="139.54118"
+           y="227.84328">(0,10]</tspan></text>
+    </g>
+    <g
+       id="g8620-6-7-1-2-2-1-4-9-6"
+       transform="translate(-27.29443,-9.0077894)">
+      <rect
+         style="fill:#ffffff;stroke-width:0.799999;stroke-linecap:round;paint-order:markers fill stroke"
+         id="rect4791-6-4-5-0-9-8-1-3-5"
+         width="22.771273"
+         height="8.9705019"
+         x="137.21416"
+         y="221.91898"
+         ry="3.3172145"
+         rx="3.2101941" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05556px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#373737;fill-opacity:1;stroke:none;stroke-width:0.264583"
+         x="139.54118"
+         y="227.84328"
+         id="text3241-7-4-5-7-7-7-6-8-5"><tspan
+           sodipodi:role="line"
+           id="tspan3239-8-9-5-4-5-1-1-0-8"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.05556px;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#373737;fill-opacity:1;stroke-width:0.264583"
+           x="139.54118"
+           y="227.84328">(0,10]</tspan></text>
     </g>
     <text
        xml:space="preserve"


### PR DESCRIPTION
Adds two `(0,10]` labels to the pedigree diagram. Not sure if I like this or not, but having it in means we can say that we show all the edge annotations in the first generation but not upwards from that.

I won't merge yet, but we can leave this as an open PR until we decide which we prefer.