### PR TITLE
Update Fig 1 caption to refer to A, B, C

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -381,15 +381,11 @@ $(\textsf{f}, \textsf{g})$ & $(0, L]$ \\
 
 \end{tikzpicture}
 \caption{\label{fig-arg-data-structure}
-Node vs edge breakpoint annotations.
-The classical approach described by Griffiths
-equates graph nodes with events in the stochastic process,
-and associates recombination breakpoint information with \emph{nodes} (left).
-This encoding
-is limited in the patterns of inheritance that can be described
-and requires that edges be ordered to avoid ambiguity.
-The alternative is to associate breakpoint annotations
-with \emph{edges} (right).
+A classical ARG (subfigure B), contrasting node with edge breakpoint annotations.
+(A) recombination breakpoint information encoded on \emph{nodes}.
+This encoding is limited in the patterns of inheritance that can be
+described and requires that edges be ordered to avoid ambiguity.
+(C) breakpoint annotations associated with \emph{edges}.
 Associating the interval of genome inherited by the child node
 from the parent with the corresponding edge allows
 any pattern genetic inheritance to be described and does


### PR DESCRIPTION
It's slightly clumsy having the graph in the middle when describing A, B, C, but I think it's visually best this way.