### PR TITLE
Remove description of W&H node u as a MRCA

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -781,7 +781,7 @@ node \textsf{j} and so it is unlikey to be inferred.
 Likewise, is is unlikely we would have information to infer the ``grand MRCA''
 \textsf{w} as all regions of the genome have already reached a
 common ancestor separately
-(in nodes \textsf{o}, \textsf{u}  and \textsf{v}).
+(in nodes \textsf{o} and \textsf{v}).
 
 % Third, there exist nodes such as
 % \textsf{k} with two children (i.e. ``common ancestor'' nodes in Hudson's terminology)


### PR DESCRIPTION
I think the only common ancestors that are present in the simplified TS will be o and v