### PR TITLE
Remove "local" as an edge annotation description

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -729,12 +729,11 @@ from the literature \citep{wiuf1999recombination} and illustrates
 how a classical eARG (Fig~\ref{fig-ancestry-resolution}A) can be described as
 a gARG with edge annotations (Figs~\ref{fig-ancestry-resolution}B~and~C).
 
-There are two distinct annotation schemes possible, and the
-distinction is subtle and important.
-The first scheme is to use the annotations to describe
-the complete set of genomic intervals inherited by the descendant node from the
-ancestor node (Fig~\ref{fig-ancestry-resolution}B). The second is to use the edge annotations to describe
-the ``ancestral material''~\citep{wiuf1999ancestry,wiuf1999recombination}
+There are two distinct annotation schemes possible, and the distinction is subtle
+and important. The first scheme is to use the annotations to describe the complete
+set of genomic intervals directly inherited by the descendant node from the ancestor
+node (Fig~\ref{fig-ancestry-resolution}B). The second is to use the edge annotations to
+describe the ``ancestral material''~\citep{wiuf1999ancestry,wiuf1999recombination}
 of the sample that is propagated through
 the graph from descendant to ancestor (Fig~\ref{fig-ancestry-resolution}C).
 
@@ -766,11 +765,10 @@ ARGs are inherently a retrospective structure defined in terms
 of a set of sample nodes (usually the leaves), and,
 as we discuss in section XXX, storing sample-resolved ancestry
 intervals (Fig~\ref{fig-ancestry-resolution}C) is generally much more
-useful than storing the local parent-child intervals of inheritance
+useful than storing the parent-child intervals recording direct inheritance
 (Fig~\ref{fig-ancestry-resolution}B).
-Indeed, storing local parent-child
-inheritance intervals for edges is really only of interest because of
-its direct correspondence with the classical approach of associating
+Indeed, storing direct inheritance intervals for edges is really only of interest because of
+its correspondence with the classical approach of associating
 breakpoints with recombination nodes in an eARG (Fig~\ref{fig-ancestry-resolution}A).
 The eARG encoding is simply a more limited form, in which the only types of direct
 inheritance we can have are the entire genome, or the intervals
@@ -792,19 +790,19 @@ common ancestor separately (in nodes \textsf{k} and \textsf{p}).
 % the breakpoint, although they retain the information that a breakpoint occurred between
 % positions 2 and 4 (which is sufficient for calculating the likelihood, see appendix XXX).
 
-Given the local inheritance edge annotations
+Given the direct-inheritance edge annotations
 (Fig~\ref{fig-ancestry-resolution}B),
  we obtain the sample-resolved edge annotation
 (Fig~\ref{fig-ancestry-resolution}C) by traversing the graph backwards in time
 from sample nodes (\textsf{a}, \textsf{b}, \textsf{c}).
 Proceeding in topological order (such that an ancestor node is visited
-after all of its descendants) the ancestral material for a node is the
-union of the ancestral intervals on its inbound edges. We then annotate
-the outbound edges with the intersection of their local inheritance intervals
-and the just-computed ancestral intervals for the node.
+after all of its descendants) the sample-resolved material for a node is the
+union of the sample-resolved intervals on its inbound edges. We then annotate
+the outbound edges with the intersection of their direct-inheritance intervals
+and the just-computed sample-resolved intervals for the node.
 For example, node \textsf{i} in Fig~\ref{fig-ancestry-resolution}C
-carries ancestral material on the intervals $(0, 2]$ and $(4, 7]$. The edge
-joining \textsf{i} to its ancestor \textsf{k} then carries ancestral
+carries sample-resolved material on the intervals $(0, 2]$ and $(4, 7]$. The edge
+joining \textsf{i} to its ancestor \textsf{k} then carries
 material on $(0, 2]$ since although \textsf{i} directly inherits interval
 $(0, 3]$ from \textsf{k} (Fig~\ref{fig-ancestry-resolution}B), only $(0, 2]$ is
 ancestral to the sample. This process is directly analogous to Hudson's


### PR DESCRIPTION
We agreed at some point that it could be confusing to use "local inheritance" as a term, as it could get mixed up with "local trees". I prefer "direct-inheritance" (versus "samnple-resolved" inheritance). This PR attempts to reword it in that way.