### PR TITLE
Change colour scheme

### DIFF
--- a/argutils/viz.py
+++ b/argutils/viz.py
@@ -17,12 +17,12 @@ import scipy.stats
 def arity_colors(n_parents):
     assert n_parents >= 0
     if n_parents == 0:
-        return colorcet.cm.CET_I1(255)  # Red
+        return colorcet.cm.CET_I1(0)  # Blue
     if n_parents == 1:
-        return colorcet.cm.CET_I1(200)  # Yellow
+        return colorcet.cm.CET_I1(100)  # Green
     # Max out at full blue if 6 or more parents; use log scale
     multiple_parents_val = (min(np.log2(n_parents), np.log2(6)) - 1) / (np.log2(6) - 1)
-    return colorcet.cm.CET_I1(100 - int(multiple_parents_val * 100))
+    return colorcet.cm.CET_I1(200 + int(multiple_parents_val * 100))
 
 
 def make_color(rgb, lighten=0):

--- a/illustrations.py
+++ b/illustrations.py
@@ -39,7 +39,7 @@ def ancestry_resolution():
             0.96,
             0.96,
             linewidth=2,
-            edgecolor='k',
+            edgecolor='tab:green',
             facecolor='white',
         )
         a.add_patch(icon)
@@ -176,7 +176,7 @@ def ancestry_resolution():
     edges = ts.tables.edges    
     for n in G.nodes:
         if G.nodes[n]["flags"] & argutils.ancestry.NODE_IS_RECOMB:
-            col = 'r'
+            col = 'tab:red'
             size = (1, 0.8)
             breaks = (edges.left[edges.child == n], edges.right[edges.child == n])
             breaks = np.unique(np.concatenate(breaks))
@@ -185,7 +185,7 @@ def ancestry_resolution():
             assert breaks[2] == ts.sequence_length
             breakpoint = breaks[1]
         else:
-            col = 'k' if ts.node(n).is_sample() else 'g'
+            col = 'k' if ts.node(n).is_sample() else 'tab:blue'
             size = (0.5, 1)
             breakpoint = None
         xf, yf = tr_figure(pos[n])


### PR DESCRIPTION
If we have RE and red and CA as blue, that's more colourblind friendly. We can then use green for genomes (alliterative!) which will help in the cellular diagram too.

We can then change the colour scheme for coalescent ARGs so that nodes with lots of parents (representing lots of recombination) get redder, whereas nodes with only one parent are still green. I think this new scheme ticks all the boxes, although we could revert to black oval outlines in fig 3 if we don't like the proliferation of colours.